### PR TITLE
Use URL-aware data.json reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,9 +83,10 @@
     <script src="https://cdn.datatables.net/2.0.7/js/dataTables.min.js" crossorigin="anonymous"></script>
 
     <script>
+        const url = window.location.href.includes("index.html") ? "data.json" : window.location.href + "/data.json";
         const table = new DataTable("#data-table", {
             ajax: {
-                url: "data.json",
+                url: url,
                 dataSrc: "",
             },
             columns: [


### PR DESCRIPTION
Small fix to make it so that a redirect from `tld` can appropriately link to the relative `data.json` file even if the URL is internally rewritten.

Example:

mydomain.biz/backpay could be rewritten to `mydomain.biz/backpay/index.html` under the hood, but then the `data.json` reference would be mydomain.biz/data.json instead of mydomain.biz/backpay/data.json. 
